### PR TITLE
fix: build on `main` push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 on:
+  push:
+    branches:
+      - main
   pull_request:
 jobs:
   build:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,4 @@
-name: ⭐️ Deploy dev
+name: ⭐️ Deploy development
 on:
   workflow_dispatch:
   repository_dispatch:


### PR DESCRIPTION
## Why

To deploy on `main` branch as well.
The artifact are bonded with the branch on upload.