### PR TITLE
feat: add setup gcloud to CI

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -29,6 +29,8 @@ jobs:
           service_account: ${{ secrets.GCP_SA }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
+      - uses: google-github-actions/setup-gcloud@v2
+
       - run: gsutil -m -h "Cache-Control:no-store" rsync -dr dist gs://${{ vars.GCS_DEST }}
 
       - name: Upload artifacts

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,4 +27,6 @@ jobs:
           service_account: ${{ secrets.GCP_SA }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
+      - uses: google-github-actions/setup-gcloud@v2
+
       - run: gsutil -m -h "Cache-Control:no-store" rsync -dr dist gs://${{ vars.GCS_DEST }}


### PR DESCRIPTION
## Why

Because `gsutil` needs to know the credentials 🔑 